### PR TITLE
Bump Python versions: 2.7.13 -> 2.7.16, 3.6.2 -> 3.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PYENV_ROOT /root/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
 # Install python 2 and 3
-RUN pyenv install 2.7.13 \
-  && pyenv install 3.6.2 \
+RUN pyenv install 2.7.16 \
+  && pyenv install 3.7.3 \
   && pyenv rehash        \
-  && pyenv global 3.6.2
+  && pyenv global 3.7.3


### PR DESCRIPTION
What do you think?

A number of security issues are resolved in both Python 2.x and 3.x latest series.