### PR TITLE
Bump devon_rex_base to 1.3.1 - run as user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM quay.io/actcat/devon_rex_base:1.2.1
+FROM quay.io/actcat/devon_rex_base:1.3.1
 
 # Install pyenv
+USER $RUNNER_USER
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-
-ENV PYENV_ROOT /root/.pyenv
-ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
+ENV PYENV_SHIMS_BIN="$RUNNER_USER_HOME/.pyenv/shims"
+ENV PYENV_BIN="$RUNNER_USER_HOME/.pyenv/bin"
+ENV PATH="$PYENV_SHIMS_BIN:$PYENV_BIN:$PATH"
 
 # Install python 2 and 3
 RUN pyenv install 2.7.16 \
   && pyenv install 3.7.2 \
   && pyenv rehash        \
   && pyenv global 3.7.2
+
+# Edit secure_path to include PATH required by Python
+USER root
+RUN sed -i -e '/secure_path/d' /etc/sudoers && \
+    echo "Defaults secure_path=\"$GEM_HOME/bin:$PYENV_SHIMS_BIN:$PYENV_BIN:/usr/local/bin:/usr/bin:/bin\"" >> /etc/sudoers


### PR DESCRIPTION
Use devon_rex_base:1.3.1 to run runners related to Python as UNIX general user.